### PR TITLE
グループ編集機能の修正

### DIFF
--- a/app/assets/javascripts/user.js
+++ b/app/assets/javascripts/user.js
@@ -20,7 +20,7 @@ function searchNoUser(user) {
 var member_list = $("#chat-group-users")
 
 function addUser(id, name) {
-  var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-8'>
+  var html = `<div class='chat-group-user clearfix js-chat-member' id='chat-group-user-${ id }'>
                 <input name='group[user_ids][]' type='hidden' value=${ id }>
                 <p class='chat-group-user__name'>${ name }</p>
                 <a class='user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn'>削除</a>
@@ -30,11 +30,12 @@ function addUser(id, name) {
 
   $("#user-search-field").on("keyup", function() {
     var input = $("#user-search-field").val();
+    var group_id = $(".chat-group-id").val();
 
     $.ajax({
       type: 'GET',
       url: '/users',
-      data: { keyword: input },
+      data: { keyword: input, groupId: group_id },
       dataType: 'json'
     })
 

--- a/app/assets/stylesheets/modules/_group.scss
+++ b/app/assets/stylesheets/modules/_group.scss
@@ -111,6 +111,9 @@
         color: $remove_red;
       }
     }
+    a {
+      text-decoration: none;
+    }
   }
 
   &__action-btn {

--- a/app/controllers/groups_controller.rb
+++ b/app/controllers/groups_controller.rb
@@ -8,6 +8,7 @@ class GroupsController < ApplicationController
   def new
     @group = Group.new
     @group.users << current_user
+    @members = @group.users
   end
 
   def create
@@ -20,6 +21,7 @@ class GroupsController < ApplicationController
   end
 
   def edit
+    @members = @group.users
   end
 
   def update

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,11 +1,19 @@
 class UsersController < ApplicationController
 
   def index
-    @group = Group.find(params[:groupId])
-    # @ids = @group.users.ids
-    # @users = User.where.not(id:@ids).where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
-    # 新規作成の時にエラーになるので、グループIDがある時とない時でif文で分岐させる。
-    @users = User.where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
+    # GroupIdがない時（グループ新規作成時）
+    if (params[:groupId] == "")
+      @users = User.where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
+    # GroupIdがある時（グループ編集時）
+    else
+      # 編集するグループのidを変数に入れる
+      @group = Group.find(params[:groupId])
+      # グループに所属するユーザのidを変数に入れる
+      @ids = @group.users.ids
+      # メンバー追加のテキストフィールドに表示されるユーザをwhereで条件検索する。インクリメンタルサーチの時に表示される。
+      @users = User.where.not(id:@ids).where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
+    end
+
     respond_to do |format|
       format.json
     end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,11 @@
 class UsersController < ApplicationController
 
   def index
-    @users = User.where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}").limit(10)
+    @group = Group.find(params[:groupId])
+    # @ids = @group.users.ids
+    # @users = User.where.not(id:@ids).where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
+    # 新規作成の時にエラーになるので、グループIDがある時とない時でif文で分岐させる。
+    @users = User.where('(name LIKE(?)) and (id != ?)', "%#{params[:keyword]}%", "#{current_user.id}")
     respond_to do |format|
       format.json
     end

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -31,7 +31,7 @@
             %input{name: 'group[user_ids][]', type: 'hidden', value: "#{ member.id }"}
             %p.chat-group-user__name
               = member.name
-            =link_to 'edit_group_path', class: 'user-search-remove chat-group-user__btn chat-group-user__btn--removejs-remove-btn', remote: true do
+            =link_to 'edit_group_path', class: 'user-search-remove chat-group-user__btn chat-group-user__btn--remove js-remove-btn', remote: true do
               削除
   .chat-group-form__field.clearfix
     .chat-group-form__field--left

--- a/app/views/groups/_form.html.haml
+++ b/app/views/groups/_form.html.haml
@@ -1,9 +1,9 @@
-= form_for @group do |f|
-  - if @group.errors.any?
+= form_for group do |f|
+  - if group.errors.any?
     .chat-group-form__errors
-      %h2="#{@group.errors.full_messages.count}件のエラーが発生しました。"
+      %h2="#{group.errors.full_messages.count}件のエラーが発生しました。"
       %ul
-        - @group.errors.full_messages.each do |message|
+        - group.errors.full_messages.each do |message|
           %li= message
 
   .chat-group-form__field.clearfix
@@ -11,13 +11,13 @@
       = f.label :name, class: 'chat-group-form__label'
     .chat-group-form__field--right
       = f.text_field :name, class: 'chat-group-form__input', placeholder: "グループ名を入力してください"
+      = f.hidden_field :id, class: 'chat-group-id', value: group.id
 
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
       =f.label :"チャットメンバーを追加", class: 'chat-group-form__label'
     .chat-group-form__field--right
       .chat-group-form__search.clearfix
-      -# = f.text_field :name, class: 'chat-group-form__input', id: 'user-search-field', placeholder: "追加したいユーザー名を入力してください"
       %input#user-search-field.chat-group-form__input{placeholder: "追加したいユーザー名を入力してください"}
       #user-search-result
 
@@ -25,12 +25,14 @@
     .chat-group-form__field--left
       = f.label :"チャットメンバー", class: 'chat-group-form__label'
     .chat-group-form__field--right
-      #chat-group-users
-        .chat-group-user.clearfix
-          %input{ name: "group[user_ids][]", type: 'hidden', value: "#{current_user.id}" }
-          %p.chat-group-user__name
-            = current_user.name
-
+      - members.each do |member|
+        #chat-group-users
+          .chat-group-user.clearfix{ id: "chat-group-user-#{member.id}" }
+            %input{name: 'group[user_ids][]', type: 'hidden', value: "#{ member.id }"}
+            %p.chat-group-user__name
+              = member.name
+            =link_to 'edit_group_path', class: 'user-search-remove chat-group-user__btn chat-group-user__btn--removejs-remove-btn', remote: true do
+              削除
   .chat-group-form__field.clearfix
     .chat-group-form__field--left
     .chat-group-form__field--right

--- a/app/views/groups/edit.html.haml
+++ b/app/views/groups/edit.html.haml
@@ -1,3 +1,3 @@
 .chat-group-form
   %h1 チャットグループ編集
-  = render partial: 'form', locals: { group: @group }
+  = render partial: 'form', locals: { group: @group, members: @members }

--- a/app/views/groups/new.html.haml
+++ b/app/views/groups/new.html.haml
@@ -1,3 +1,3 @@
 .chat-group-form
   %h1 新規チャットグループ
-  =render 'form', {group: @group}
+  =render 'form', {group: @group, members: @members}


### PR DESCRIPTION
# WHAT
グループ編集機能の修正。
グループ編集の際、カレントユーザだけでなく、すでに登録されている他のメンバーも、チャットメンバーのところに表示されるように修正した。

# WHY
すでにグループに登録されているメンバーが追加したいユーザとして表示されてしまうのは、ユーザが使用する際にわかりづらいため。